### PR TITLE
Bump python-libnmap version to 0.7.3

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,16 +2,4 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-PYTHON-PYTHONLIBNMAP-2808864:
-    - '*':
-        reason: >-
-          python-libnmap is only used to parse nmap output. It's not used to
-          execute nmap. No fix available at the moment
-        expires: 2022-09-04T17:10:10.695Z
-        created: 2022-06-04T17:10:10.697Z
-  SNYK-JS-MOMENT-2944238:
-    - '*':
-        reason: No fix available yet
-        expires: 2022-09-07T21:30:04.511Z
-        created: 2022-07-08T21:30:04.520Z
 patch: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pycryptodome==3.11.0
 psycopg2==2.9.1
 pyjwt==2.4.0
 python-magic==0.4.24
-python-libnmap==0.7.2
+python-libnmap==0.7.3
 python-telegram-bot==13.7
 pyyaml==6.0.0
 requests==2.26.0


### PR DESCRIPTION
Fix [vulnerability](https://security.snyk.io/vuln/SNYK-PYTHON-PYTHONLIBNMAP-2808864) in python-libnmap detected by Snyk.