### PR TITLE
Compatibility with previous version of the configuration system

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -116,16 +116,6 @@
     }
   ],
   "results": {
-    ".github/workflows/check-installation.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/check-installation.yml",
-        "hashed_secret": "676701817a660c7e61fcce2184b24e966f8a5034",
-        "is_verified": false,
-        "line_number": 7,
-        "is_secret": false
-      }
-    ],
     ".github/workflows/security-secrets.yml": [
       {
         "type": "Secret Keyword",
@@ -283,6 +273,14 @@
         "hashed_secret": "81eb3c56210ff29c8aa0bd0fc9891b5d47aafbc0",
         "is_verified": false,
         "line_number": 30,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "rekono/rekono/environment.py",
+        "hashed_secret": "3b63db4d1fd654e07cfe2b8bc0efbf3f0d2958d1",
+        "is_verified": false,
+        "line_number": 47,
         "is_secret": false
       }
     ],
@@ -833,5 +831,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-27T13:37:42Z"
+  "generated_at": "2022-10-31T20:02:28Z"
 }

--- a/rekono/rekono/config.py
+++ b/rekono/rekono/config.py
@@ -50,6 +50,17 @@ class RekonoConfigLoader:
         )
         self.TOOLS_GITTOOLS_DIR = self.get_config_key(config, ['tools', 'gittools', 'directory'], '/opt/GitTools')
 
+        # --------------------------------------------------------------------------------------------------------------
+        # DEPRECATED
+        # The following configurations are mantained for compatibility reasons with the previous version.
+        # This support will be removed in the next release, since this settings can be managed using the Settings page.
+        # --------------------------------------------------------------------------------------------------------------
+        # Telegram Bot token
+        self.TELEGRAM_TOKEN = self.get_config_key(config, ['telegram', 'token'])
+        # Defect-Dojo
+        self.DD_URL = self.get_config_key(config, ['defect-dojo', 'url'])
+        self.DD_API_KEY = self.get_config_key(config, ['defect-dojo', 'api-key'])
+
     def get_config_key(self, config: Dict[str, Any], path: List[str], default: Any = None) -> Any:
         '''Get configuration value by dict path. Default value will be returned if value not found or it's null.
 

--- a/rekono/rekono/environment.py
+++ b/rekono/rekono/environment.py
@@ -33,3 +33,15 @@ RKN_EMAIL_PASSWORD = 'RKN_EMAIL_PASSWORD'
 RKN_CMSEEK_RESULTS = 'RKN_CMSEEK_RESULTS'
 RKN_LOG4J_SCANNER_DIR = 'RKN_LOG4J_SCANNER_DIR'
 RKN_GITTOOLS_DIR = 'RKN_GITTOOLS_DIR'
+
+
+# --------------------------------------------------------------------------------------------------------------
+# DEPRECATED
+# The following configurations are mantained for compatibility reasons with the previous version.
+# This support will be removed in the next release, since this settings can be managed using the Settings page.
+# --------------------------------------------------------------------------------------------------------------
+# Telegram bot configuration
+RKN_TELEGRAM_TOKEN = 'RKN_TELEGRAM_TOKEN'
+# Defect-Dojo configuration
+RKN_DD_URL = 'RKN_DD_URL'
+RKN_DD_API_KEY = 'RKN_DD_API_KEY'

--- a/rekono/rekono/settings.py
+++ b/rekono/rekono/settings.py
@@ -17,6 +17,7 @@ from typing import Any, Dict
 
 from findings.enums import Severity
 from input_types.enums import InputTypeNames
+from system.models import System
 from targets.enums import TargetType
 from tasks.enums import Status, TimeUnit
 from tools.enums import IntensityRank
@@ -25,11 +26,12 @@ from rekono.config import RekonoConfigLoader
 from rekono.environment import (ENV_REKONO_HOME, RKN_ALLOWED_HOSTS,
                                 RKN_CMSEEK_RESULTS, RKN_DB_HOST, RKN_DB_NAME,
                                 RKN_DB_PASSWORD, RKN_DB_PORT, RKN_DB_USER,
-                                RKN_EMAIL_HOST, RKN_EMAIL_PASSWORD,
-                                RKN_EMAIL_PORT, RKN_EMAIL_USER,
-                                RKN_FRONTEND_URL, RKN_GITTOOLS_DIR,
-                                RKN_LOG4J_SCANNER_DIR, RKN_RQ_HOST,
-                                RKN_RQ_PORT, RKN_SECRET_KEY, RKN_TRUSTED_PROXY)
+                                RKN_DD_API_KEY, RKN_DD_URL, RKN_EMAIL_HOST,
+                                RKN_EMAIL_PASSWORD, RKN_EMAIL_PORT,
+                                RKN_EMAIL_USER, RKN_FRONTEND_URL,
+                                RKN_GITTOOLS_DIR, RKN_LOG4J_SCANNER_DIR,
+                                RKN_RQ_HOST, RKN_RQ_PORT, RKN_SECRET_KEY,
+                                RKN_TELEGRAM_TOKEN, RKN_TRUSTED_PROXY)
 
 ################################################################################
 # Rekono basic information                                                     #
@@ -428,3 +430,19 @@ STATIC_ROOT = os.path.join(REKONO_HOME, 'static')
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
+# --------------------------------------------------------------------------------------------------------------
+# DEPRECATED
+# The following configurations are mantained for compatibility reasons with the previous version.
+# This support will be removed in the next release, since this settings can be managed using the Settings page.
+# --------------------------------------------------------------------------------------------------------------
+system = System.objects.first()
+for environment_variable, file_property, system_field in [
+    (RKN_TELEGRAM_TOKEN, CONFIG.TELEGRAM_TOKEN, 'telegram_bot_token'),
+    (RKN_DD_URL, CONFIG.DD_URL, 'defect_dojo_url'),
+    (RKN_DD_API_KEY, CONFIG.DD_API_KEY, 'defect_dojo_api_key'),
+]:
+    if os.getenv(environment_variable, file_property) and not getattr(system, system_field):
+        setattr(system, system_field, os.getenv(environment_variable, file_property))
+system.save()


### PR DESCRIPTION
In the new Rekono configuration approach the Defect-Dojo URL, API key and the Telegram token are configured using the new Settings page (#71). The old approach based on environment variables and configuration files will be removed, but for the moment, this fix is needed to save this configuration in the new model. In this way, the Rekono environments already configured won't crash.