### PR TITLE
Validate targets to prevent scanning of internal Rekono infrastructure

### DIFF
--- a/rekono/targets/utils.py
+++ b/rekono/targets/utils.py
@@ -4,6 +4,7 @@ import re
 import socket
 
 from django.core.exceptions import ValidationError
+
 from targets.enums import TargetType
 
 # Regex to match IP ranges like 10.10.10.1-20
@@ -24,6 +25,14 @@ def get_target_type(target: str) -> str:
     Returns:
         str: Target type associated to the target
     '''
+    if target in [
+        '127.0.0.1', 'localhost', 'frontend', 'backend',
+        'postgres', 'redis', 'postfix', 'initialize',
+        'tasks-worker', 'executions-worker', 'findings-worker',
+        'emails-worker', 'telegram-bot', 'nginx'
+    ]:
+        # Target is invalid
+        raise ValidationError({'target': f'Invalid target {target}'})
     try:
         # Check if target is an IP address (IPv4 or IPv6)
         ip = ipaddress.ip_address(target)

--- a/rekono/testing/api/test_targets.py
+++ b/rekono/testing/api/test_targets.py
@@ -39,6 +39,8 @@ class TargetsTest(RekonoApiTestCase):
         self.api_test(self.client.post, self.endpoint, 400, data=self.used_data)    # Target already exists
         self.used_data['target'] = 'invalid'
         self.api_test(self.client.post, self.endpoint, 400, data=self.used_data)    # Invalid target
+        self.used_data['target'] = '127.0.0.1'
+        self.api_test(self.client.post, self.endpoint, 400, data=self.used_data)    # Invalid internal target
 
     def test_delete(self) -> None:
         '''Test target deletion feature.'''


### PR DESCRIPTION
Localhost and Docker environment hostnames are invalid targets