### PR TITLE
Remove input parameters from process executions

### DIFF
--- a/rekono/processes/executor/executor.py
+++ b/rekono/processes/executor/executor.py
@@ -6,7 +6,6 @@ from executions import utils
 from executions.models import Execution
 from executions.queue import producer
 from input_types.models import InputType
-from parameters.models import InputTechnology, InputVulnerability
 from processes.executor.callback import process_callback
 from processes.models import Step
 from rq.job import Job
@@ -98,14 +97,6 @@ def execute(task: Task) -> None:
         if f'{app_label}.{TargetPort._meta.model_name}' not in covered_targets:
             # TargetPort is not covered by dependencies
             targets.extend(list(task.target.target_ports.all()))                # Add task target ports to targets
-        if f'{app_label}.{InputTechnology._meta.model_name}' not in covered_targets:
-            # InputTechnology is not covered by dependencies
-            # Add input technologies to task targets
-            targets.extend(list(InputTechnology.objects.filter(target=task.target).all()))
-        if f'{app_label}.{InputVulnerability._meta.model_name}' not in covered_targets:
-            # InputVulnerability is not covered by dependencies
-            # Add input vulnerabilities to task targets
-            targets.extend(list(InputVulnerability.objects.filter(target=task.target).all()))
         # Get the executions required for this job based on targets and tool arguments.
         # A job can need multiple executions. For example, if the user includes more than one Wordlist and
         # the process includes Dirsearch execution that only accepts one wordlist as argument. Rekono will


### PR DESCRIPTION
During process executions, technologies and vulnerabilities should be detected by the tools that belong to the process. So that, use input technologies and vulnerabilities in process executions when real technologies and vulnerabilities haven't been detected don't make sense.