### PR TITLE
Add rekono-kbx installation to the README

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,6 +3,10 @@ on:
   release:
     types: [published]
 
+env:
+  GITLAB_REKONO_ID: 45783845
+  GITLAB_KALI_FORK_ID: 48406619
+
 jobs:
   docker-image:
     name: Docker Image
@@ -43,24 +47,26 @@ jobs:
 
   debian-package:
     name: Debian Package
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - git-add-files: .
+            source-proect-id: ${{ env.GITLAB_REKONO_ID }}
+            source-branch: release/${{ github.event.release.name }}
+            target-project-id: ${{ env.GITLAB_REKONO_ID }}
+            target-branch: kali/master
+          - git-add-files: rekono
+            source-project-id: ${{ env.GITLAB_REKONO_ID }}
+            source-branch: kali-release/${{ github.event.release.name }}
+            target-project-id: ${{ env.GITLAB_KALI_FORK_ID }}
+            target-branch: kali/master
     runs-on: ubuntu-latest
     environment: gitlab
     needs: docker-image
     steps:
       - name: Checkout GitLab repository
         run: git clone https://gitlab.com/pablosnt/rekono.git rekono-deb
-      
-      - name: Update README.md
-        working-directory: rekono-deb
-        shell: python
-        run: |
-          import re
-          with open('README.md', 'r') as readme:
-            content = readme.read()
-          line_to_replace = re.search(f'dpkg -i ../rekono_[\d\.]+_amd64.deb', content)
-          if line_to_replace:
-            with open('README.md', 'w') as readme:
-              readme.write(content.replace(line_to_replace.group(0), 'dpkg -i ../rekono_${{ github.event.release.name }}_amd64.deb'))
 
       - name: Update rekono executable
         working-directory: rekono-deb
@@ -79,7 +85,7 @@ jobs:
           tz = pytz.timezone('Europe/Madrid')
           d = tz.localize(datetime.now())
           change_time = d.strftime('%a, %d %b %Y %H:%M:%S %z')
-          new_changes = f'rekono (${{ github.event.release.name }}) UNRELEASED; urgency=medium\n\n  * Update Rekono version to ${{ github.event.release.name }}.\n\n -- Pablo Santiago López <${{ secrets.GITLAB_EMAIL }}>  {change_time}\n\n'
+          new_changes = f'rekono-kbx (${{ github.event.release.name }}) kali-dev; urgency=medium\n\n  * Update Rekono version to ${{ github.event.release.name }}.\n\n -- Pablo Santiago López <${{ secrets.GITLAB_EMAIL }}>  {change_time}\n\n'
           with open('changelog', 'w') as changelog:
             changelog.write(new_changes + old_changes)
       
@@ -88,16 +94,14 @@ jobs:
         run: |
           git config user.name 'Pablo Santiago'
           git config user.email '${{ secrets.GITLAB_EMAIL }}'
-          git checkout -b release/${{ github.event.release.name }}
-          git add .
+          git checkout -b ${{ matrix.source-branch }}
+          git add ${{ matrix.git-add-files }}
           git commit -m "Update Rekono version to ${{ github.event.release.name }}"
           git config credential.helper '!f() { sleep 1; echo "username=${{ secrets.GITLAB_USER }}"; echo "password=${{ secrets.GITLAB_TOKEN }}"; }; f'
-          git push --set-upstream origin release/${{ github.event.release.name }}
+          git push --set-upstream origin ${{ matrix.source-branch }}
       
       - name: GitLab merge request
         shell: python
-        env:
-          GITLAB_PROJECT_ID: 45783845
         run: |
           import requests
           headers = {
@@ -105,10 +109,12 @@ jobs:
           }
           data = {
             'title': 'Update Rekono version to ${{ github.event.release.name }}',
-            'source_branch': 'release/${{ github.event.release.name }}',
-            'target_branch': 'kali/master',
+            'source_project_id': ${{ matrix.source-project-id }},
+            'source_branch': '${{ matrix.source-branch }}',
+            'target_project_id': ${{ matrix.target-project-id }},
+            'target_branch': '${{ matrix.target-branch }}'
           }
-          response = requests.post('https://gitlab.com/api/v4/projects/${{ env.GITLAB_PROJECT_ID }}/merge_requests', data=data, headers=headers)
+          response = requests.post('https://gitlab.com/api/v4/projects/${{ matrix.target-project-id }}/merge_requests', data=data, headers=headers)
           if response.status_code != 201:
             print(response.text)
           assert(response.status_code == 201)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ Why not automate this process and focus on find vulnerabilities using your skill
 
 ## Quick Start
 
+### Rekono Desktop
+
+Rekono Desktop is a standalone app that can be easily installed and executed locally. Install it on **Kali Linux** with this command:
+
+```bash
+apt install rekono-kbx
+```
+
+If you are using **Parrot OS**, you can download the Debian package from the Rekono release:
+
+```bash
+wget https://github.com/pablosnt/rekono/releases/download/1.6.3/rekono-kbx_1.6.3_amd64.deb && dpkg -i rekono-kbx_1.6.3_amd64.deb || apt -f install -y
+```
+
+> Default credentials are `rekono:rekono`. For security reasons, **password should be changed** the first time you access the account
+
+
 ### Docker
 
 Execute the following commands in the root directory of the project:
@@ -71,19 +88,6 @@ Go to https://127.0.0.1/
 > Default credentials are `rekono:rekono`. For security reasons, **password should be changed** the first time you access the account. Moreover default user details can be changed using [environment variables](https://github.com/pablosnt/rekono/wiki/Configuration#docker).
 
 > The number of workers can be changed using `--scale` option. The number of `executions-worker` determines the number of tools that could be executed at the same time.
-
-
-### Rekono Desktop
-
-Rekono Desktop is a standalone app with all features, that can be installed and executed locally. It's the best and easiest option for personal and local usage. Execue the following command to install it:
-
-```bash
-wget https://github.com/pablosnt/rekono/releases/download/1.6.3/rekono-desktop_1.6.3_amd64.deb && dpkg -i rekono-desktop_1.6.3_amd64.deb || apt -f install -y
-```
-
-> Default credentials are `rekono:rekono`. For security reasons, **password should be changed** the first time you access the account
-
-> :warning: Rekono Desktop only has been tested in Kali Linux and Parrot OS
 
 
 Check [**full documentation**](https://github.com/pablosnt/rekono/wiki) for more installation and configuration options, user guides, integrations, Rekono Desktop, Rekono Bot and Rekono CLI details.


### PR DESCRIPTION
Rekono Desktop is available on Kali Linux with the `rekono-kbx` name: http://pkg.kali.org/pkg/rekono-kbx