### PR TITLE
Optimize integrations not to waste rate limits

### DIFF
--- a/backend/platforms/cvecrowd/fixtures/1_default.json
+++ b/backend/platforms/cvecrowd/fixtures/1_default.json
@@ -5,7 +5,8 @@
         "fields": {
             "_api_token": null,
             "trending_span_days": 7,
-            "execute_per_execution": true
+            "execute_per_execution": true,
+            "is_available": false
         }
     }
 ]

--- a/backend/platforms/cvecrowd/integrations.py
+++ b/backend/platforms/cvecrowd/integrations.py
@@ -6,7 +6,10 @@ automated alerting for security teams. The integration supports both per-executi
 processing and bulk monitoring capabilities for comprehensive threat intelligence.
 """
 
+from datetime import timedelta
 from functools import cached_property
+
+from django.utils import timezone
 
 from alerts.enums import AlertItem
 from alerts.models import Alert
@@ -15,7 +18,7 @@ from findings.enums import TriageStatus
 from findings.framework.models import Finding
 from findings.models import Vulnerability
 from framework.platforms import BaseIntegration
-from platforms.cvecrowd.models import CveCrowdSettings
+from platforms.cvecrowd.models import CveCrowdCache, CveCrowdSettings
 from platforms.mail.notifications import SMTP
 from platforms.telegram_app.notifications import Telegram
 
@@ -47,19 +50,24 @@ class CveCrowd(BaseIntegration):
 
     @cached_property
     def trending_cves(self) -> list[str]:
-        return self.get_trending_cves()
+        return self.get_trending_cves(True)
 
-    def get_trending_cves(self) -> list[str]:
-        """Retrieve and cache trending CVE data from the CVE Crowd API.
+    def get_trending_cves(self, use_cache: bool) -> list[str]:
+        if use_cache:
+            cache = CveCrowdCache.objects.order_by("date")
+            if cache.exists():
+                first = cache.first()
+                if first.date > (timezone.now() - timedelta(days=1)):
+                    return cache.values_list("cve", flat=True)
+        CveCrowdCache.objects.all().delete()
+        cves = self.download_trending_cves()
+        if len(cves) > 0:
+            CveCrowdCache.objects.bulk_create([CveCrowdCache(cve=cve, date=timezone.now()) for cve in cves])
+        return cves
 
-        Fetches current trending vulnerability data using the configured API
-        credentials and trending analysis timeframe. Results are cached for
-        efficient access during vulnerability processing operations.
-
-        Returns:
-            list[str]: List of trending CVE identifiers, empty list if unavailable.
-        """
-        if self.integration.enabled and self.settings.secret:
+    def download_trending_cves(self) -> list[str]:
+        if self.settings.secret:
+            # TOTEST: We don't have API access
             try:
                 return self._request(
                     self.session.get,

--- a/backend/platforms/cvecrowd/integrations.py
+++ b/backend/platforms/cvecrowd/integrations.py
@@ -34,7 +34,7 @@ class CveCrowd(BaseIntegration):
     """
 
     finding_types = [Vulnerability]
-    url = "https://api.cvecrowd.com/api/v1/cves"
+    url = "https://api.cvecrowd.com/api/v2/cves"
 
     @property
     def settings(self) -> CveCrowdSettings:
@@ -47,6 +47,9 @@ class CveCrowd(BaseIntegration):
 
     @cached_property
     def trending_cves(self) -> list[str]:
+        return self.get_trending_cves()
+
+    def get_trending_cves(self) -> list[str]:
         """Retrieve and cache trending CVE data from the CVE Crowd API.
 
         Fetches current trending vulnerability data using the configured API
@@ -77,9 +80,7 @@ class CveCrowd(BaseIntegration):
         Returns:
             bool: True if the platform is available and has trending data, False otherwise.
         """
-        if self.settings.secret:
-            return len(self.trending_cves) > 0
-        return False
+        return self.settings.is_available
 
     def _process_finding(self, execution: Execution, finding: Vulnerability) -> None:
         """Process a vulnerability finding by marking it as trending.

--- a/backend/platforms/cvecrowd/integrations.py
+++ b/backend/platforms/cvecrowd/integrations.py
@@ -48,6 +48,17 @@ class CveCrowd(BaseIntegration):
         """
         return CveCrowdSettings.objects.first()
 
+    def is_available(self) -> bool:
+        """Check if the CVE Crowd platform is available and accessible.
+
+        Validates platform connectivity by checking for valid API credentials
+        and successful trending CVE data retrieval.
+
+        Returns:
+            bool: True if the platform is available and has trending data, False otherwise.
+        """
+        return self.settings.is_available
+
     @cached_property
     def trending_cves(self) -> list[str]:
         return self.get_trending_cves(True)
@@ -78,17 +89,6 @@ class CveCrowd(BaseIntegration):
             except Exception:
                 pass
         return []
-
-    def is_available(self) -> bool:
-        """Check if the CVE Crowd platform is available and accessible.
-
-        Validates platform connectivity by checking for valid API credentials
-        and successful trending CVE data retrieval.
-
-        Returns:
-            bool: True if the platform is available and has trending data, False otherwise.
-        """
-        return self.settings.is_available
 
     def _process_finding(self, execution: Execution, finding: Vulnerability) -> None:
         """Process a vulnerability finding by marking it as trending.

--- a/backend/platforms/cvecrowd/integrations.py
+++ b/backend/platforms/cvecrowd/integrations.py
@@ -51,19 +51,51 @@ class CveCrowd(BaseIntegration):
     def is_available(self) -> bool:
         """Check if the CVE Crowd platform is available and accessible.
 
-        Validates platform connectivity by checking for valid API credentials
-        and successful trending CVE data retrieval.
+        Returns the availability status stored in the database, which is updated
+        each time the platform settings are saved.
 
         Returns:
             bool: True if the platform is available and has trending data, False otherwise.
         """
         return self.settings.is_available
 
+    def live_is_available(self) -> bool:
+        """Check if the CVE Crowd platform is available by performing a live API request.
+
+        Validates platform connectivity by fetching trending CVE data directly from
+        the API, bypassing the database cache. Returns True if at least one trending
+        CVE is returned.
+
+        Returns:
+            bool: True if the platform is reachable and returns trending data, False otherwise.
+        """
+        return len(self.get_trending_cves(False)) > 0
+
     @cached_property
     def trending_cves(self) -> list[str]:
+        """Trending CVEs from CVE Crowd, cached for the lifetime of the instance.
+
+        Uses the database cache to avoid redundant API requests. Delegates to
+        get_trending_cves with cache enabled.
+
+        Returns:
+            list[str]: List of CVE identifiers currently trending on CVE Crowd.
+        """
         return self.get_trending_cves(True)
 
     def get_trending_cves(self, use_cache: bool) -> list[str]:
+        """Retrieve the list of trending CVEs from CVE Crowd, optionally using the database cache.
+
+        When cache is enabled, returns stored CVE data if it was collected within the last day.
+        If the cache is expired or empty, fetches fresh data from the API, stores it in the
+        database, and returns the result.
+
+        Args:
+            use_cache (bool): Whether to use the database cache to avoid redundant API requests.
+
+        Returns:
+            list[str]: List of CVE identifiers currently trending on CVE Crowd.
+        """
         if use_cache:
             cache = CveCrowdCache.objects.order_by("date")
             if cache.exists():
@@ -77,6 +109,16 @@ class CveCrowd(BaseIntegration):
         return cves
 
     def download_trending_cves(self) -> list[str]:
+        """Download the list of trending CVEs directly from the CVE Crowd API.
+
+        Makes an authenticated request to the CVE Crowd API endpoint, passing the
+        configured trending span in days. Returns an empty list if no API token is
+        configured or if the request fails.
+
+        Returns:
+            list[str]: List of CVE identifiers currently trending on CVE Crowd,
+                or an empty list on failure.
+        """
         if self.settings.secret:
             # TOTEST: We don't have API access
             try:

--- a/backend/platforms/cvecrowd/models.py
+++ b/backend/platforms/cvecrowd/models.py
@@ -1,15 +1,17 @@
 """Django models for CVE Crowd platform integration settings.
 
-This module provides the core data model for CVE Crowd platform configuration,
-enabling secure storage of API credentials and monitoring settings. The model
-supports encrypted credential storage and configurable trending analysis parameters
+This module provides the data models for CVE Crowd platform configuration,
+enabling secure storage of API credentials, monitoring settings, and a
+database-backed cache for trending CVE data. The settings model supports
+encrypted credential storage and configurable trending analysis parameters
 for comprehensive vulnerability threat intelligence integration.
 
 Architecture:
     The settings model extends BaseEncrypted to provide automatic encryption for
     sensitive API credentials while maintaining flexible configuration options
     for trending analysis timeframes and execution patterns within the security
-    assessment workflow.
+    assessment workflow. The cache model stores trending CVE identifiers to
+    avoid redundant API requests across multiple executions.
 """
 
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -28,9 +30,10 @@ class CveCrowdSettings(BaseEncrypted):
     monitoring and prioritization.
 
     Attributes:
-        _api_token (TextField): Encrypted CVE Crowd API bearer token (max 50 chars)
-        trending_span_days (IntegerField): Days for trending analysis (1-7, default 7)
-        execute_per_execution (BooleanField): Enable per-execution processing (default True)
+        _api_token (TextField): Encrypted CVE Crowd API bearer token (max 50 chars).
+        trending_span_days (IntegerField): Days for trending analysis (1-30, default 7).
+        execute_per_execution (BooleanField): Enable per-execution processing (default True).
+        is_available (BooleanField): Cached platform availability status (default False).
 
     Example:
         Configure CVE Crowd integration with 3-day trending window:
@@ -68,5 +71,16 @@ class CveCrowdSettings(BaseEncrypted):
 
 
 class CveCrowdCache(BaseModel):
+    """Cache model for trending CVE identifiers retrieved from the CVE Crowd API.
+
+    Stores CVE identifiers with their retrieval timestamp to avoid redundant API
+    requests. The cache is considered valid for one day; all entries are replaced
+    atomically when the cache is expired or a forced refresh is triggered.
+
+    Attributes:
+        cve (TextField): CVE identifier (e.g., CVE-2024-12345), max 20 chars.
+        date (DateTimeField): Timestamp when this entry was stored in the cache.
+    """
+
     cve = models.TextField(max_length=20)
     date = models.DateTimeField()

--- a/backend/platforms/cvecrowd/models.py
+++ b/backend/platforms/cvecrowd/models.py
@@ -15,7 +15,7 @@ Architecture:
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from framework.models import BaseEncrypted
+from framework.models import BaseEncrypted, BaseModel
 from security.validators.input_validator import Regex, Validator
 
 
@@ -65,3 +65,8 @@ class CveCrowdSettings(BaseEncrypted):
             str: Platform name "CVE Crowd".
         """
         return "CVE Crowd"
+
+
+class CveCrowdCache(BaseModel):
+    cve = models.TextField(max_length=20)
+    date = models.DateTimeField()

--- a/backend/platforms/cvecrowd/models.py
+++ b/backend/platforms/cvecrowd/models.py
@@ -52,8 +52,9 @@ class CveCrowdSettings(BaseEncrypted):
         blank=True,
         db_column="api_token",
     )
-    trending_span_days = models.IntegerField(default=7, validators=[MinValueValidator(1), MaxValueValidator(7)])
+    trending_span_days = models.IntegerField(default=7, validators=[MinValueValidator(1), MaxValueValidator(30)])
     execute_per_execution = models.BooleanField(default=True)
+    is_available = models.BooleanField(default=False)
 
     _encrypted_field = "_api_token"
 

--- a/backend/platforms/cvecrowd/serializers.py
+++ b/backend/platforms/cvecrowd/serializers.py
@@ -32,6 +32,6 @@ class CveCrowdSettingsSerializer(ModelSerializer):
 
     def update(self, instance, validated_data):
         instance = super().update(instance, validated_data)
-        instance.is_available = len(CveCrowd().trending_cves) > 0
+        instance.is_available = len(CveCrowd().get_trending_cves(False)) > 0
         instance.save(update_fields=["is_available"])
         return instance

--- a/backend/platforms/cvecrowd/serializers.py
+++ b/backend/platforms/cvecrowd/serializers.py
@@ -31,7 +31,19 @@ class CveCrowdSettingsSerializer(ModelSerializer):
         read_only_fields = ("is_available",)
 
     def update(self, instance, validated_data):
+        """Update CVE Crowd settings and refresh the platform availability status.
+
+        Delegates to the parent update method, then performs a live API check to
+        update the is_available field in the database.
+
+        Args:
+            instance (CveCrowdSettings): The settings instance to update.
+            validated_data (dict): Validated data from the request.
+
+        Returns:
+            CveCrowdSettings: The updated settings instance.
+        """
         instance = super().update(instance, validated_data)
-        instance.is_available = len(CveCrowd().get_trending_cves(False)) > 0
+        instance.is_available = CveCrowd().live_is_available()
         instance.save(update_fields=["is_available"])
         return instance

--- a/backend/platforms/cvecrowd/serializers.py
+++ b/backend/platforms/cvecrowd/serializers.py
@@ -5,7 +5,7 @@ for API operations. Includes secure credential handling, validation logic,
 and platform availability detection for threat intelligence integration.
 """
 
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
+from rest_framework.serializers import ModelSerializer
 
 from framework.fields import ProtectedSecretField
 from platforms.cvecrowd.integrations import CveCrowd
@@ -21,27 +21,17 @@ class CveCrowdSettingsSerializer(ModelSerializer):
 
     Attributes:
         api_token (ProtectedSecretField): Protected API token field with validation
-        is_available (SerializerMethodField): Platform availability status
     """
 
     api_token = ProtectedSecretField(required=False, allow_null=True, source="secret")
-    is_available = SerializerMethodField(read_only=True)
-    client = CveCrowd()
 
     class Meta:
         model = CveCrowdSettings
         fields = ("id", "trending_span_days", "execute_per_execution", "api_token", "is_available")
+        read_only_fields = ("is_available",)
 
-    def get_is_available(self, instance: CveCrowdSettings) -> bool:
-        """Check if the CVE Crowd platform is available and accessible.
-
-        Validates platform connectivity and API accessibility using the
-        configured credentials and settings.
-
-        Args:
-            instance (CveCrowdSettings): The settings instance being serialized.
-
-        Returns:
-            bool: True if the platform is available and accessible, False otherwise.
-        """
-        return self.client.is_available()
+    def update(self, instance, validated_data):
+        instance = super().update(instance, validated_data)
+        instance.is_available = len(CveCrowd().trending_cves) > 0
+        instance.save(update_fields=["is_available"])
+        return instance

--- a/backend/platforms/virustotal/fixtures/1_default.json
+++ b/backend/platforms/virustotal/fixtures/1_default.json
@@ -3,7 +3,8 @@
         "model": "virustotal.virustotalsettings",
         "pk": 1,
         "fields": {
-            "_api_token": null
+            "_api_token": null,
+            "is_available": false
         }
     }
 ]

--- a/backend/platforms/virustotal/integrations.py
+++ b/backend/platforms/virustotal/integrations.py
@@ -50,6 +50,9 @@ class VirusTotal(BaseIntegration):
         return VirusTotalSettings.objects.first()
 
     def is_available(self) -> bool:
+        return self.settings.is_available
+
+    def live_is_available(self) -> bool:
         """Check if the VirusTotal platform is available and accessible.
 
         Validates platform connectivity by checking for valid API credentials

--- a/backend/platforms/virustotal/integrations.py
+++ b/backend/platforms/virustotal/integrations.py
@@ -50,6 +50,14 @@ class VirusTotal(BaseIntegration):
         return VirusTotalSettings.objects.first()
 
     def is_available(self) -> bool:
+        """Check if the VirusTotal platform is available and accessible.
+
+        Returns the availability status stored in the database, which is updated
+        each time the platform settings are saved.
+
+        Returns:
+            bool: True if the platform is available and accessible, False otherwise.
+        """
         return self.settings.is_available
 
     def live_is_available(self) -> bool:

--- a/backend/platforms/virustotal/models.py
+++ b/backend/platforms/virustotal/models.py
@@ -21,7 +21,8 @@ class VirusTotalSettings(BaseEncrypted):
 
     Attributes:
         _api_token (TextField): Encrypted VirusTotal API token for authentication.
-                               Validated using SECRET regex pattern for security.
+            Validated using SECRET regex pattern for security.
+        is_available (BooleanField): Cached platform availability status (default False).
 
     Example:
         Configure VirusTotal API credentials:

--- a/backend/platforms/virustotal/models.py
+++ b/backend/platforms/virustotal/models.py
@@ -44,6 +44,7 @@ class VirusTotalSettings(BaseEncrypted):
         blank=True,
         db_column="api_token",
     )
+    is_available = models.BooleanField(default=False)
 
     _encrypted_field = "_api_token"
 

--- a/backend/platforms/virustotal/serializers.py
+++ b/backend/platforms/virustotal/serializers.py
@@ -27,18 +27,23 @@ class VirusTotalSettingsSerializer(ModelSerializer):
     api_token = ProtectedSecretField(required=False, allow_null=True, source="secret")
 
     class Meta:
-        """Serializer metadata configuration.
-
-        Defines the model and fields for VirusTotal settings serialization.
-        Includes platform configuration ID, encrypted API token, and real-time
-        availability status for comprehensive platform management.
-        """
-
         model = VirusTotalSettings
         fields = ("id", "api_token", "is_available")
         read_only_fields = ("is_available",)
 
     def update(self, instance, validated_data):
+        """Update VirusTotal settings and refresh the platform availability status.
+
+        Delegates to the parent update method, then performs a live API check to
+        update the is_available field in the database.
+
+        Args:
+            instance (VirusTotalSettings): The settings instance to update.
+            validated_data (dict): Validated data from the request.
+
+        Returns:
+            VirusTotalSettings: The updated settings instance.
+        """
         instance = super().update(instance, validated_data)
         instance.is_available = VirusTotal().live_is_available()
         instance.save(update_fields=["is_available"])

--- a/backend/platforms/virustotal/serializers.py
+++ b/backend/platforms/virustotal/serializers.py
@@ -5,7 +5,7 @@ and configuration management through REST API endpoints. Supports secure
 handling of API credentials and real-time platform availability checking.
 """
 
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
+from rest_framework.serializers import ModelSerializer
 
 from framework.fields import ProtectedSecretField
 from platforms.virustotal.integrations import VirusTotal
@@ -22,14 +22,9 @@ class VirusTotalSettingsSerializer(ModelSerializer):
     Attributes:
         api_token (ProtectedSecretField): Secure API token field with
                                           encryption
-        is_available (SerializerMethodField): Real-time platform availability
-                                              status
-        client (VirusTotal): Integration client for availability checking
     """
 
     api_token = ProtectedSecretField(required=False, allow_null=True, source="secret")
-    is_available = SerializerMethodField(read_only=True)
-    client = VirusTotal()
 
     class Meta:
         """Serializer metadata configuration.
@@ -41,20 +36,10 @@ class VirusTotalSettingsSerializer(ModelSerializer):
 
         model = VirusTotalSettings
         fields = ("id", "api_token", "is_available")
+        read_only_fields = ("is_available",)
 
-    def get_is_available(self, instance: VirusTotalSettings) -> bool:
-        """Get real-time availability status of the VirusTotal platform.
-
-        Checks if the VirusTotal platform is currently accessible and
-        responsive
-        by performing a test API request with the configured credentials.
-
-        Args:
-            instance (VirusTotalSettings): The settings instance being
-                                          serialized
-
-        Returns:
-            bool: True if VirusTotal is available and accessible, False
-                  otherwise
-        """
-        return self.client.is_available()
+    def update(self, instance, validated_data):
+        instance = super().update(instance, validated_data)
+        instance.is_available = VirusTotal().live_is_available()
+        instance.save(update_fields=["is_available"])
+        return instance

--- a/backend/tests/platforms/test_cvecrowd.py
+++ b/backend/tests/platforms/test_cvecrowd.py
@@ -54,6 +54,8 @@ class CveCrowdTest(BaseTest, TestCase):
         self.cvecrowd.process_findings(self.execution, [self.trending, self.not_trending])
         self.assertTrue(Vulnerability.objects.get(pk=self.trending.id).trending)
         self.assertFalse(Vulnerability.objects.get(pk=self.not_trending.id).trending)
+        # Rerun to force cache usage
+        self.cvecrowd.process_findings(self.execution, [self.trending, self.not_trending])
 
     @mock.patch("platforms.cvecrowd.integrations.CveCrowd._request", not_found)
     def test_process_findings_not_found(self) -> None:
@@ -93,6 +95,9 @@ class CveCrowdTest(BaseTest, TestCase):
     @mock.patch("platforms.cvecrowd.integrations.CveCrowd._request", exception)
     def test_is_not_available_2(self) -> None:
         self.assertFalse(self.cvecrowd.live_is_available())
+
+    def test_cached_is_available(self) -> None:
+        self.assertFalse(self.cvecrowd.is_available())
 
 
 new_settings = {"api_token": "cve-crowd-token", "trending_span_days": 3, "execute_per_execution": False}

--- a/backend/tests/platforms/test_cvecrowd.py
+++ b/backend/tests/platforms/test_cvecrowd.py
@@ -55,7 +55,7 @@ class CveCrowdTest(BaseTest, TestCase):
         self.assertTrue(Vulnerability.objects.get(pk=self.trending.id).trending)
         self.assertFalse(Vulnerability.objects.get(pk=self.not_trending.id).trending)
         # Rerun to force cache usage
-        self.cvecrowd.process_findings(self.execution, [self.trending, self.not_trending])
+        CveCrowd().process_findings(self.execution, [self.trending, self.not_trending])
 
     @mock.patch("platforms.cvecrowd.integrations.CveCrowd._request", not_found)
     def test_process_findings_not_found(self) -> None:

--- a/backend/tests/platforms/test_cvecrowd.py
+++ b/backend/tests/platforms/test_cvecrowd.py
@@ -84,19 +84,19 @@ class CveCrowdTest(BaseTest, TestCase):
 
     @mock.patch("platforms.cvecrowd.integrations.CveCrowd._request", success)
     def test_is_available(self) -> None:
-        self.assertTrue(self.cvecrowd.is_available())
+        self.assertTrue(self.cvecrowd.live_is_available())
 
     @mock.patch("platforms.cvecrowd.integrations.CveCrowd._request", not_found)
     def test_is_not_available_1(self) -> None:
-        self.assertFalse(self.cvecrowd.is_available())
+        self.assertFalse(self.cvecrowd.live_is_available())
 
     @mock.patch("platforms.cvecrowd.integrations.CveCrowd._request", exception)
     def test_is_not_available_2(self) -> None:
-        self.assertFalse(self.cvecrowd.is_available())
+        self.assertFalse(self.cvecrowd.live_is_available())
 
 
 new_settings = {"api_token": "cve-crowd-token", "trending_span_days": 3, "execute_per_execution": False}
-invalid_settings = {**new_settings, "trending_span_days": 10}
+invalid_settings = {**new_settings, "trending_span_days": 50}
 
 
 class CveCrowdSettingsTest(ApiTestNoData, TestCase):

--- a/backend/tests/platforms/test_virustotal.py
+++ b/backend/tests/platforms/test_virustotal.py
@@ -72,15 +72,15 @@ class VirusTotalTest(BaseTest, TestCase):
 
     @mock.patch("platforms.virustotal.integrations.VirusTotal._request", success)
     def test_is_available(self) -> None:
-        self.assertTrue(self.virustotal.is_available())
+        self.assertTrue(self.virustotal.live_is_available())
 
     @mock.patch("platforms.virustotal.integrations.VirusTotal._request", exception)
     def test_is_not_available(self) -> None:
-        self.assertFalse(self.virustotal.is_available())
+        self.assertFalse(self.virustotal.live_is_available())
 
         self.settings.secret = None
         self.settings.save(update_fields=["_api_token"])
-        self.assertFalse(self.virustotal.is_available())
+        self.assertFalse(self.virustotal.live_is_available())
 
 
 new_settings = {"api_token": "cve-crowd-token"}

--- a/backend/tests/platforms/test_virustotal.py
+++ b/backend/tests/platforms/test_virustotal.py
@@ -82,6 +82,9 @@ class VirusTotalTest(BaseTest, TestCase):
         self.settings.save(update_fields=["_api_token"])
         self.assertFalse(self.virustotal.live_is_available())
 
+    def test_cached_is_available(self) -> None:
+        self.assertFalse(self.virustotal.is_available())
+
 
 new_settings = {"api_token": "cve-crowd-token"}
 invalid_settings = {"api_token": "x" * 70}

--- a/backend/tools/parsers/base.py
+++ b/backend/tools/parsers/base.py
@@ -12,11 +12,11 @@ from pathlib import Path
 from typing import Any
 
 import defusedxml.ElementTree as parser
-from findings.models import OSINT, Host
 from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
 from django.db.models.query_utils import DeferredAttribute
 
 from findings.framework.models import Finding
+from findings.models import OSINT, Host
 from parameters.models import InputTechnology, InputVulnerability
 from rekono.settings import CONFIG
 from target_ports.models import TargetPort

--- a/frontend/app/components/admin/integrations.vue
+++ b/frontend/app/components/admin/integrations.vue
@@ -155,10 +155,10 @@ const integrationsSettings = ref({
           key: "trending_span_days",
           label: "Trending Span Days",
           type: "number",
-          placeholder: "Enter number of days (1-7)",
+          placeholder: "Enter number of days (1-30)",
           required: true,
           min: 1,
-          max: 7,
+          max: 30,
         },
         {
           key: "execute_per_execution",
@@ -172,7 +172,7 @@ const integrationsSettings = ref({
         trending_span_days: z
           .number()
           .min(1, "Must be at least 1")
-          .max(7, "Must be at most 7"),
+          .max(30, "Must be at most 30"),
         execute_per_execution: z.boolean(),
       }),
     },


### PR DESCRIPTION
- [x] Keep CveCrowd `is_available` on database and update it on settings change
- [x] Keep CveCrowd daily cache to avoid making many requests to receive the same data
- [x] Keep VirusTotal `is_available` on database and update it on settings change